### PR TITLE
Fix crash during finalization.

### DIFF
--- a/src/JavaScriptEngineSwitcher.ChakraCore/ChakraCoreJsEngine.cs
+++ b/src/JavaScriptEngineSwitcher.ChakraCore/ChakraCoreJsEngine.cs
@@ -1117,14 +1117,14 @@ namespace JavaScriptEngineSwitcher.ChakraCore
 		{
 			if (_disposedFlag.Set())
 			{
-				if (_dispatcher != null)
-				{
-					_dispatcher.Invoke(() => _jsRuntime.Dispose());
-					_dispatcher.Dispose();
-				}
-
 				if (disposing)
 				{
+					if (_dispatcher != null)
+					{
+						_dispatcher.Invoke(() => _jsRuntime.Dispose());
+						_dispatcher.Dispose();
+					}
+
 					if (_externalObjects != null)
 					{
 						_externalObjects.Clear();


### PR DESCRIPTION
.NET does not guarantee the order which objects will be finalized. A
crash would occur if ScriptDispatcher has already been finalized.

This crash can be repo'd under IIS Express by trying to quit gracefully from the console.