### PR TITLE
Use 'stack' instead of 'message' to capture full stack trace.

### DIFF
--- a/src/JavaScriptEngineSwitcher.ChakraCore/ChakraCoreJsEngine.cs
+++ b/src/JavaScriptEngineSwitcher.ChakraCore/ChakraCoreJsEngine.cs
@@ -876,7 +876,7 @@ namespace JavaScriptEngineSwitcher.ChakraCore
 				category = "Script error";
 				JsValue errorValue = jsScriptException.Error;
 
-				JsValue messagePropertyValue = errorValue.GetProperty("message");
+				JsValue messagePropertyValue = errorValue.GetProperty("stack");
 				string scriptMessage = messagePropertyValue.ConvertToString().ToString();
 				if (!string.IsNullOrWhiteSpace(scriptMessage))
 				{


### PR DESCRIPTION
Instead of just a message, the exception now includes a full stack
trace (similar to the V8 engine).

Found it by trial-and-error using the immediate window and referencing
this file, so there may be a better way to do this.

https://github.com/Microsoft/ChakraCore/blob/8d3d7c81a585aff9afb427d0a187ffdeb05e95c3/bin/ch/WScriptJsrt.cpp#L1050