### PR TITLE
Add net471 target

### DIFF
--- a/src/JavaScriptEngineSwitcher.Core/JavaScriptEngineSwitcher.Core.csproj
+++ b/src/JavaScriptEngineSwitcher.Core/JavaScriptEngineSwitcher.Core.csproj
@@ -4,7 +4,7 @@
 		<Product>JS Engine Switcher: Core</Product>
 		<VersionPrefix>3.0.0</VersionPrefix>
 		<VersionSuffix>beta3</VersionSuffix>
-		<TargetFrameworks>net40-client;net45;netstandard1.3;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net40-client;net45;net471;netstandard1.3;netstandard2.0</TargetFrameworks>
 		<NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
 		<OutputType>Library</OutputType>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/JavaScriptEngineSwitcher.Core/Utilities/TypeConverter.cs
+++ b/src/JavaScriptEngineSwitcher.Core/Utilities/TypeConverter.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Globalization;
-#if NET45 || NETSTANDARD
+#if NET45 || NET471 || NETSTANDARD
 using System.Reflection;
 #endif
 using OriginalTypeConverter = System.ComponentModel.TypeConverter;


### PR DESCRIPTION
- .NET Framework 4.7.1+ implements System.Runtime.InteropServices.RuntimeInformation so don't need to have dependency on external NuGet package like .NET 4.5

Implements #54